### PR TITLE
Made ban appeal form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Discord channel webhook to receive ban appeals
+# Create in Discord: Channel Settings -> Integrations -> Webhooks -> New Webhook
+DISCORD_BAN_APPEAL_WEBHOOK_URL="https://discord.com/api/webhooks/XXXXXXXX/YYYYYYYY"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- Ban appeal form at `/ban-appeal` that submits to `/api/ban-appeal` and delivers appeals to a Discord channel via webhook
 - Animated terminal window component with typewriter effect and language switcher (Python / TypeScript / Rust)
 - `Features` section — 8-card grid covering community offerings (help desk, code reviews, OSS hub, etc.)
 - `TechMarquee` component — dual-row infinite scrolling marquee of 28+ languages and frameworks

--- a/README.md
+++ b/README.md
@@ -41,3 +41,25 @@ This project is configured to deploy on [Netlify](https://www.netlify.com/).
 The repository includes a `netlify.toml` with these settings and uses the official `@netlify/plugin-nextjs` to run Next.js on Netlify's edge/functions environment.
 
 For more details, see the [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) and the [Netlify Next.js docs](https://docs.netlify.com/integrations/frameworks/next-js/).
+
+## Ban appeal form → Discord webhook
+
+This repo includes a ban appeal page at `/ban-appeal`.
+
+To receive submissions in a Discord channel:
+
+1. In Discord, open the target channel → **Edit Channel** → **Integrations** → **Webhooks** → **New Webhook**.
+2. Copy the webhook URL.
+3. Set the env var `DISCORD_BAN_APPEAL_WEBHOOK_URL`.
+
+Local dev:
+
+```bash
+cp .env.example .env.local
+```
+
+Then paste your webhook into `.env.local`.
+
+Netlify:
+
+- Add `DISCORD_BAN_APPEAL_WEBHOOK_URL` in **Site settings → Environment variables**.

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -2,7 +2,7 @@
 title: Frequently Asked Questions
 description: Answers to common questions about roles, events, bots, learning, safety, and support in the CodeVerse Hub Discord community.
 icon: help-circle
-lastUpdated: March 2026
+lastUpdated: May 2026
 ---
 
 > Before posting in public channels, skim this FAQ first — many common questions are already answered here.
@@ -139,6 +139,11 @@ If you see suspicious or inappropriate behaviour:
 3. Optionally ping an **online moderator** if the situation is urgent (for example, ongoing harassment or dangerous content).
 
 Staff will review the report, take appropriate action, and may follow up with you for additional details if needed.
+
+### How do I appeal a ban?
+
+- Use the ban appeal form at `/ban-appeal` (recommended), and include evidence links if possible.
+- If you cannot access the website, open a ModMail ticket by DMing the @ModMail bot.
 
 ---
 

--- a/content/pages/moderation-guide.md
+++ b/content/pages/moderation-guide.md
@@ -2,7 +2,7 @@
 title: Moderation Guide
 description: Guidelines for reporting rule violations and understanding how the moderation team handles incidents.
 icon: gavel
-lastUpdated: February 2026
+lastUpdated: May 2026
 ---
 
 > Our moderation team is committed to keeping the community safe. If you see a violation, please report it — your help makes our community better.
@@ -34,8 +34,11 @@ Moderators should:
 
 Users may appeal moderation actions by:
 
-1. **Opening a ModMail ticket** — Explain why they believe the action was unjust
-2. **Providing context** — Include any relevant information or evidence
-3. **Waiting for review** — The moderation team will review the appeal and respond accordingly
+1. **Submitting the ban appeal form** — Use `/ban-appeal` to send your appeal to the moderation team
+2. **Or opening a ModMail ticket** — DM the @ModMail bot if you cannot access the website
+3. **Providing context** — Include any relevant information or evidence
+4. **Waiting for review** — The moderation team will review the appeal and respond accordingly
+
+> Tip: Be honest, include evidence links when relevant, and avoid leaving out key details.
 
 > We strive to be fair and transparent in all moderation decisions. If you feel you've been treated unfairly, we encourage you to appeal.

--- a/content/pages/privacy-policy.md
+++ b/content/pages/privacy-policy.md
@@ -2,7 +2,7 @@
 title: Privacy Policy
 description: How CodeVerse Hub handles, stores, and protects your data as a member of our community.
 icon: lock
-lastUpdated: February 2026
+lastUpdated: May 2026
 ---
 
 > Privacy and security of member data is one of our top priorities. This document details what data CodeVerse Hub ("we", "us", or "our") stores on you as a member of our community.
@@ -13,6 +13,7 @@ lastUpdated: February 2026
 - **Infraction Records** — When a user breaches our rules, we store a record of the infraction (warn/ban/kick) linked to their User ID. This is essential for moderation history
 - **ModMail Logs** — All messages sent to our ModMail bot are stored to facilitate support and moderation oversight
 - **Message Logs** — We do not permanently store general chat logs. However, deleted messages may be temporarily logged for moderation review
+- **Website Form Submissions (Ban Appeals)** — If you submit a ban appeal via our website, the information you provide is delivered to the moderation team (for review) through our internal tooling
 
 ---
 

--- a/content/pages/rules.md
+++ b/content/pages/rules.md
@@ -2,7 +2,7 @@
 title: Rules of CodeVerse Hub
 description: The complete set of community rules that keep our server safe, respectful, and enjoyable for everyone.
 icon: shield
-lastUpdated: February 2026
+lastUpdated: May 2026
 ---
 
 > These rules exist to protect every member and ensure CodeVerse Hub remains a friendly, welcoming space. Please read them carefully — ignorance is not an excuse.
@@ -92,6 +92,8 @@ These rules are not exhaustive. Trying to bypass rules is not allowed. If you're
 ## Respect Moderation Decisions
 
 Do not disrupt the server if you disagree with a punishment. Appeal respectfully through proper channels.
+
+Ban appeals can be submitted via `/ban-appeal` (recommended) or through ModMail if you cannot access the website.
 
 If bias is suspected after appeal, contact staff in this order via tickets/modmail only:
 

--- a/src/app/api/ban-appeal/route.ts
+++ b/src/app/api/ban-appeal/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+
+function normalizeOptionalString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim();
+}
+
+function truncate(value: string, maxLen: number): string {
+  if (value.length <= maxLen) return value;
+  return value.slice(0, Math.max(0, maxLen - 1)) + "…";
+}
+
+export async function POST(req: Request) {
+  const webhookUrl = process.env.DISCORD_BAN_APPEAL_WEBHOOK_URL;
+  if (!webhookUrl) {
+    return NextResponse.json(
+      { error: "Server misconfigured: missing webhook." },
+      { status: 500 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 });
+  }
+
+  const data = body as Record<string, unknown>;
+
+  // Honeypot (bots tend to fill hidden fields)
+  const website = normalizeOptionalString(data.website);
+  if (website) {
+    return NextResponse.json({ ok: true }, { status: 200 });
+  }
+
+  const discordUsername = normalizeOptionalString(data.discordUsername);
+  const discordUserId = normalizeOptionalString(data.discordUserId);
+  const email = normalizeOptionalString(data.email);
+  const banReason = normalizeOptionalString(data.banReason);
+  const appeal = normalizeOptionalString(data.appeal);
+  const evidenceLink = normalizeOptionalString(data.evidenceLink);
+
+  if (!discordUsername) {
+    return NextResponse.json(
+      { error: "Discord username is required." },
+      { status: 400 },
+    );
+  }
+
+  if (!appeal) {
+    return NextResponse.json({ error: "Appeal is required." }, { status: 400 });
+  }
+
+  // Keep within Discord embed limits.
+  const safeDiscordUsername = truncate(discordUsername, 256);
+  const safeDiscordUserId = truncate(discordUserId, 64);
+  const safeEmail = truncate(email, 256);
+  const safeBanReason = truncate(banReason, 256);
+  const safeAppeal = truncate(appeal, 3500);
+  const safeEvidenceLink = truncate(evidenceLink, 512);
+
+  const fields = [
+    { name: "Discord", value: safeDiscordUsername || "—", inline: false },
+    {
+      name: "User ID",
+      value: safeDiscordUserId || "—",
+      inline: true,
+    },
+    { name: "Email", value: safeEmail || "—", inline: true },
+    { name: "Ban reason (self-reported)", value: safeBanReason || "—", inline: false },
+  ].filter(Boolean);
+
+  if (safeEvidenceLink) {
+    fields.push({ name: "Evidence", value: safeEvidenceLink, inline: false });
+  }
+
+  const payload = {
+    embeds: [
+      {
+        title: "Ban Appeal",
+        description: safeAppeal,
+        color: 0x8b5cf6,
+        fields,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+
+  try {
+    const discordRes = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!discordRes.ok) {
+      return NextResponse.json(
+        { error: "Failed to deliver appeal." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to deliver appeal." },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/ban-appeal/page.tsx
+++ b/src/app/ban-appeal/page.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import GradientText from "@/components/GradientText";
+import { CheckCircle, Send } from "lucide-react";
+
+type SubmitState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success" }
+  | { status: "error"; message: string };
+
+export default function BanAppealPage() {
+  const [state, setState] = useState<SubmitState>({ status: "idle" });
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (state.status === "submitting") return;
+
+    setState({ status: "submitting" });
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+
+    const payload = {
+      discordUsername: String(formData.get("discordUsername") || "").trim(),
+      discordUserId: String(formData.get("discordUserId") || "").trim(),
+      email: String(formData.get("email") || "").trim(),
+      banReason: String(formData.get("banReason") || "").trim(),
+      appeal: String(formData.get("appeal") || "").trim(),
+      evidenceLink: String(formData.get("evidenceLink") || "").trim(),
+      website: String(formData.get("website") || "").trim(),
+    };
+
+    try {
+      const res = await fetch("/api/ban-appeal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        setState({
+          status: "error",
+          message: data?.error || "Something went wrong. Please try again.",
+        });
+        return;
+      }
+
+      setState({ status: "success" });
+      form.reset();
+    } catch {
+      setState({
+        status: "error",
+        message: "Network error. Please try again.",
+      });
+    }
+  };
+
+  return (
+    <div className="bg-black min-h-screen flex flex-col">
+      <Navbar />
+
+      <main className="flex-1 w-full max-w-5xl mx-auto px-4 md:px-6 py-16 md:py-20">
+        <header className="text-center mb-10">
+          <h1 className="text-3xl sm:text-4xl md:text-6xl font-bold text-white">
+            Ban{" "}
+            <GradientText
+              colors={["#8B5CF6", "#EC4899", "#8B5CF6"]}
+              className="inline"
+            >
+              Appeal
+            </GradientText>
+          </h1>
+          <p className="mt-4 text-white/50 max-w-2xl mx-auto">
+            Fill out the form below. After you submit, it will be sent to our
+            moderation team for review.
+          </p>
+        </header>
+
+        <section className="w-full max-w-3xl mx-auto">
+          <div className="p-6 md:p-8 rounded-2xl border border-white/10 bg-white/5">
+            {state.status === "success" ? (
+              <div className="flex flex-col items-center justify-center text-center py-10">
+                <CheckCircle className="w-16 h-16 text-green-400 mb-4" />
+                <h2 className="text-2xl font-bold text-white mb-2">
+                  Appeal submitted
+                </h2>
+                <p className="text-white/50">
+                  Thanks — your appeal was sent to the team.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setState({ status: "idle" })}
+                  className="mt-6 text-violet-400 hover:text-violet-300 transition-colors"
+                >
+                  Submit another appeal
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {/* Honeypot (spam protection). Keep hidden. */}
+                <input
+                  type="text"
+                  name="website"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  className="hidden"
+                />
+
+                <div>
+                  <label
+                    htmlFor="discordUsername"
+                    className="block text-white/70 text-sm mb-2"
+                  >
+                    Discord username
+                  </label>
+                  <input
+                    type="text"
+                    id="discordUsername"
+                    name="discordUsername"
+                    required
+                    placeholder="e.g. aditya or aditya#1234"
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="discordUserId"
+                    className="block text-white/70 text-sm mb-2"
+                  >
+                    Discord user ID (optional)
+                  </label>
+                  <input
+                    type="text"
+                    id="discordUserId"
+                    name="discordUserId"
+                    inputMode="numeric"
+                    placeholder="e.g. 123456789012345678"
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="email" className="block text-white/70 text-sm mb-2">
+                    Email (optional) [May Share Ban Appeal Status]
+                  </label>
+                  <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="banReason"
+                    className="block text-white/70 text-sm mb-2"
+                  >
+                    Why do you think you were banned? (optional)
+                  </label>
+                  <input
+                    type="text"
+                    id="banReason"
+                    name="banReason"
+                    placeholder="If you know, summarize it"
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="appeal"
+                    className="block text-white/70 text-sm mb-2"
+                  >
+                    Your appeal
+                  </label>
+                  <textarea
+                    id="appeal"
+                    name="appeal"
+                    rows={6}
+                    required
+                    placeholder="Explain what happened, what you’ll do differently, and why you should be unbanned."
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors resize-none"
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="evidenceLink"
+                    className="block text-white/70 text-sm mb-2"
+                  >
+                    Evidence link (optional)
+                  </label>
+                  <input
+                    type="url"
+                    id="evidenceLink"
+                    name="evidenceLink"
+                    placeholder="https://..."
+                    className="w-full px-4 py-3 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 outline-none transition-colors"
+                  />
+                </div>
+
+                {state.status === "error" ? (
+                  <p className="text-sm text-red-400">{state.message}</p>
+                ) : null}
+
+                <button
+                  type="submit"
+                  disabled={state.status === "submitting"}
+                  className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-gradient-to-r from-violet-600 to-fuchsia-600 text-white font-bold hover:from-violet-500 hover:to-fuchsia-500 transition-all duration-300 disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  <Send className="w-4 h-4" />
+                  {state.status === "submitting" ? "Submitting..." : "Submit appeal"}
+                </button>
+
+                <p className="text-xs text-white/35 leading-relaxed">
+                  This form is sent to the moderation team via Discord webhook.
+                  Don&apos;t include passwords or sensitive info.
+                </p>
+              </form>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed?
Made a ban appeal form in root/ban-appeal, It a from made in html backend with Next js , sends an api to discord via webhooks to setup a ban appeal.

## Why?
The previous ban appeal way using codeverse bot didnt worked for ban appeals as it was Unable to send dms as appeals due to lack of presence in server.

## How to test
No Need to test
## Checklist

- [ ] I linked an issue or explained why not
- [x] I added/updated docs for user-facing changes
- [] I added/updated tests (or explained why not)
- [x] I did not commit secrets (tokens, `.env`, keys)
- [x] CI should pass for this PR

## Screenshots (optional)
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/ce8294e6-5044-469a-91f7-f893d72e4362" />

<img width="1180" height="611" alt="image" src="https://github.com/user-attachments/assets/0259b580-d33e-4255-8df1-1cfb9828d59f" />


