### PR TITLE
Fix duplicate H1 tags on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,9 +72,9 @@ export default function Home() {
                 <h1 className="text-4xl sm:text-5xl md:text-6xl xl:text-7xl font-extrabold text-white leading-[1.05] tracking-tight">
                   Build faster with a
                 </h1>
-                <h1 className="text-4xl sm:text-5xl md:text-6xl xl:text-7xl font-extrabold leading-[1.05] tracking-tight bg-gradient-to-r from-violet-300 via-fuchsia-400 to-indigo-300 bg-clip-text text-transparent">
+                <h2 className="text-4xl sm:text-5xl md:text-6xl xl:text-7xl font-extrabold leading-[1.05] tracking-tight bg-gradient-to-r from-violet-300 via-fuchsia-400 to-indigo-300 bg-clip-text text-transparent">
                   real developer community
-                </h1>
+                </h2>
                 <p className="text-white/70 text-base sm:text-lg md:text-xl leading-relaxed max-w-xl">
                   CodeVerse Hub is your always-on Discord for code reviews, open
                   source teams, mentorship, and instant help — designed for


### PR DESCRIPTION
## Summary

Refactored the homepage heading structure to ensure only one H1 tag exists for improved SEO and accessibility.

## Changes Made
- Converted the secondary H1 element into an H2
- Preserved the existing visual styling and layout
- Maintained proper semantic heading hierarchy
## Verification
- Confirmed the homepage now contains exactly one H1
- Verified no visual changes were introduced
- Tested heading hierarchy using browser inspection tools
