### PR TITLE
Add skip link for keyboard accessibility

### DIFF
--- a/src/app/ban-appeal/page.tsx
+++ b/src/app/ban-appeal/page.tsx
@@ -66,7 +66,7 @@ export default function BanAppealPage() {
     <div className="bg-black min-h-screen flex flex-col">
       <Navbar />
 
-      <main className="flex-1 w-full max-w-5xl mx-auto px-4 md:px-6 py-16 md:py-20">
+      <main id="main-content" tabIndex={-1} className="flex-1 w-full max-w-5xl mx-auto px-4 md:px-6 py-16 md:py-20">
         <header className="text-center mb-10">
           <h1 className="text-3xl sm:text-4xl md:text-6xl font-bold text-white">
             Ban{" "}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -115,6 +115,12 @@ export default function RootLayout({
         />
       </head>
       <body className="font-sans antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-black focus:outline-none focus:ring-2 focus:ring-violet-500"
+        >
+          Skip to main content
+        </a>
         {children}
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFound() {
 
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] rounded-full bg-violet-600/5 blur-[120px] pointer-events-none" />
 
-            <div className="relative z-10 flex flex-col items-center text-center">
+            <main id="main-content" tabIndex={-1} className="relative z-10 flex flex-col items-center text-center">
                 <div className="mb-4">
                     <FuzzyText
                         fontSize="clamp(5rem, 15vw, 12rem)"
@@ -35,7 +35,7 @@ export default function NotFound() {
                 </div>
 
                 <p className="text-white/50 text-lg mb-2 font-medium">
-                    bro typed a whole URL and it doesn't even exist 💀
+                    bro typed a whole URL and it doesn&apos;t even exist 💀
                 </p>
 
                 <p className="text-white/25 text-sm mb-10">
@@ -49,7 +49,7 @@ export default function NotFound() {
                     <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform duration-300" />
                     <span className="font-medium">go back before it gets worse</span>
                 </Link>
-            </div>
+            </main>
             <p className="text-white/15 text-xs mt-12 font-mono">
                 exit code: 1 — segfault in page_loader.c at 0xDUMMY
             </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,8 +19,9 @@ export default function Home() {
     <div className="bg-black">
       <Navbar />
 
-      {/* ─── HERO ────────────────────────────────────────────────── */}
-      <section className="relative min-h-screen w-full overflow-hidden flex items-center">
+      <main id="main-content" tabIndex={-1}>
+        {/* ─── HERO ────────────────────────────────────────────────── */}
+        <section className="relative min-h-screen w-full overflow-hidden flex items-center">
         {/* Background gradient */}
         <div className="absolute inset-0 z-0">
           <GradientBlinds
@@ -191,7 +192,8 @@ export default function Home() {
       <ContactSection />
 
       {/* ─── JOIN CTA ────────────────────────────────────────────── */}
-      <JoinCTA />
+        <JoinCTA />
+      </main>
 
       <Footer />
     </div>

--- a/src/app/pages/[slug]/page.tsx
+++ b/src/app/pages/[slug]/page.tsx
@@ -159,14 +159,14 @@ export default async function ContentPage({ params }: PageProps) {
         return (
             <div className="min-h-screen bg-black flex flex-col">
                 <Navbar />
-                <div className="flex-1 flex items-center justify-center px-4 py-16">
+                <main id="main-content" tabIndex={-1} className="flex-1 flex items-center justify-center px-4 py-16">
                     <div className="text-center">
                         <h1 className="text-4xl font-bold text-white mb-4">Page Not Found</h1>
                         <Link href="/" className="text-violet-400 hover:text-violet-300">
                             Return Home
                         </Link>
                     </div>
-                </div>
+                </main>
                 <Footer />
             </div>
         );
@@ -177,7 +177,7 @@ export default async function ContentPage({ params }: PageProps) {
     return (
         <div className="min-h-screen bg-black flex flex-col">
             <Navbar />
-            <div className="flex-1 max-w-7xl mx-auto px-4 py-16">
+            <main id="main-content" tabIndex={-1} className="flex-1 max-w-7xl mx-auto px-4 py-16">
                 <div className="flex items-center justify-between gap-4 mb-6">
                     <Link
                         href="/"
@@ -243,7 +243,7 @@ export default async function ContentPage({ params }: PageProps) {
                         />
                     </article>
                 </div>
-            </div>
+            </main>
             <Footer />
         </div>
     );

--- a/src/app/pages/page.tsx
+++ b/src/app/pages/page.tsx
@@ -87,7 +87,7 @@ export default function PagesIndex() {
   return (
     <div className="min-h-screen bg-black flex flex-col">
       <Navbar />
-      <main className="flex-1 max-w-5xl mx-auto px-4 md:px-6 py-16">
+      <main id="main-content" tabIndex={-1} className="flex-1 max-w-5xl mx-auto px-4 md:px-6 py-16">
         <header className="mb-10">
           <p className="text-xs font-mono uppercase tracking-[0.2em] text-violet-300/70 mb-2">
             Docs

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -897,7 +897,7 @@ export default function ResourcesPage() {
                         </div>
                     </nav>
 
-                    <main className="flex-1 min-w-0">
+                    <main id="main-content" tabIndex={-1} className="flex-1 min-w-0">
                         <div className="mb-8 p-6 rounded-2xl border border-white/10 bg-white/5">
                             <div className="flex items-center gap-3 mb-2">
                                 <span


### PR DESCRIPTION
## Summary

Adds a skip-to-content link so keyboard and screen-reader users can bypass repeated navigation and jump directly to the main content.

## What changed

- Added a `Skip to main content` link in the root layout.
- The link is visually hidden until focused.
- Added `id="main-content"` and `tabIndex={-1}` to the main landmarks on key pages.

## Why

This addresses #13 and supports WCAG 2.4.1 Bypass Blocks by giving users a reliable way to skip repeated navigation.

## Validation

- Ran targeted ESLint on the changed files.
- No new errors were introduced in the changed files.
- Note: the full project lint currently reports pre-existing unrelated issues in other files.
